### PR TITLE
Update links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ NOTE: requires [exjsx](https://github.com/talentdeficit/exjsx) as dependency
 - `Tesla.Middleware.DecodeJson` - decode response body as JSON
 - `Tesla.Middleware.EncodeJson` - endode request body as JSON
 
-If you are using different json library writing middleware should be straightforward. See [`json.ex`](https://github.com/monterail/tesla/blob/master/lib/middleware/json.ex) for implementation.
+If you are using different json library writing middleware should be straightforward. See [`json.ex`](https://github.com/monterail/tesla/blob/master/lib/tesla/middleware/json.ex) for implementation.
 
 
 ## Dynamic middleware
@@ -193,7 +193,7 @@ defmodule Tesla.Middleware.MyMiddleware do
 end
 ```
 
-See [`core.ex`](https://github.com/monterail/tesla/blob/master/lib/middleware/core.ex) and [`json.ex`](https://github.com/monterail/tesla/blob/master/lib/middleware/json.ex) for more examples.
+See [`core.ex`](https://github.com/monterail/tesla/blob/master/lib/tesla/middleware/core.ex) and [`json.ex`](https://github.com/monterail/tesla/blob/master/lib/tesla/middleware/json.ex) for more examples.
 
 
 ## Asynchronous requests


### PR DESCRIPTION
Point links to new locations for `core.ex` and `json.ex`.