### PR TITLE
remove compile warning and don't create :ok tuple everytime

### DIFF
--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -4,19 +4,18 @@ defmodule Tesla.Adapter.Ibrowse do
 
     if target = env.opts[:respond_to] do
 
-      gatherer = spawn_link fn -> gather_response(env, target, {:ok, nil, nil, nil}) end
+      gatherer = spawn_link fn -> gather_response(env, target, nil, nil, nil) end
 
       opts = opts ++ [stream_to: gatherer]
       {:ibrowse_req_id, id} = send_req(env, opts)
       {:ok, id}
     else
-      format_response(env, send_req(env, opts))
+      {:ok, status, headers, body} = send_req(env, opts)
+      format_response(env, status, headers, body)
     end
   end
 
-  defp format_response(env, res) do
-    {:ok, status, headers, body} = res
-
+  defp format_response(env, status, headers, body) do
     {status, _} = Integer.parse(to_string(status))
     headers     = Enum.into(headers, %{})
 
@@ -36,24 +35,17 @@ defmodule Tesla.Adapter.Ibrowse do
     )
   end
 
-  defp gather_response(env, target, res) do
-    {:ok, _status, _headers, _body} = res
-
+  defp gather_response(env, target, status, headers, body) do
     receive do
-      {:ibrowse_async_headers, _, status, headers} ->
-        gather_response(env, target, {:ok, status, headers, _body})
+      {:ibrowse_async_headers, _, new_status, new_headers} ->
+        gather_response(env, target, new_status, new_headers, body)
 
-      {:ibrowse_async_response, _, body} ->
-        body = if _body do
-          _body <> body
-        else
-          body
-        end
-
-        gather_response(env, target, {:ok, _status, _headers, body})
+      {:ibrowse_async_response, _, append_body} ->
+        new_body = if body, do: body <> append_body, else: append_body
+        gather_response(env, target, status, headers, new_body)
 
       {:ibrowse_async_response_end, _} ->
-        response = format_response(env, res)
+        response = format_response(env, status, headers, body)
         send target, {:tesla_response, response}
     end
   end


### PR DESCRIPTION
lib/tesla/adapter/ibrowse.ex:48: warning: the underscored variable
"_body" is used after being set. A leading underscore indicates that
the value of the variable should be ignored. If this is intended please
rename the variable to remove the underscore
lib/tesla/adapter/ibrowse.ex:51: warning: the underscored variable
"_body" is used after being set. A leading underscore indicates that
the value of the variable should be ignored. If this is intended please
rename the variable to remove the underscore
lib/tesla/adapter/ibrowse.ex:52: warning: the underscored variable
"_body" is used after being set. A leading underscore indicates that
the value of the variable should be ignored. If this is intended please
rename the variable to remove the underscore
lib/tesla/adapter/ibrowse.ex:57: warning: the underscored variable
"_status" is used after being set. A leading underscore indicates that
the value of the variable should be ignored. If this is intended please
rename the variable to remove the underscore
lib/tesla/adapter/ibrowse.ex:57: warning: the underscored variable
"_headers" is used after being set. A leading underscore indicates that
the value of the variable should be ignored. If this is intended please
rename the variable to remove the underscore